### PR TITLE
Enable jwt to be provided on query string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules/

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,8 @@ module.exports = function(options) {
       } else {
         return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));
       }
+    } else if (req.params && req.params.access_token) {
+      token = req.params.access_token;
     }
 
     if (!token) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,8 +35,8 @@ module.exports = function(options) {
       } else {
         return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));
       }
-    } else if (req.params && req.params.access_token) {
-      token = req.params.access_token;
+    } else if (req.query && req.query.access_token) {
+      token = req.query.access_token;
     }
 
     if (!token) {


### PR DESCRIPTION
Hi,

First of all, love your library. :) Thanks for making it easier to integrate AzureAD jwt verification into express.

This patch introduces support for providing the bearer token as part of the url in the query string.  With this, you may either provide a bearer token via `Authorization: Bearer <token>`, or `<url>/?access_token=<token>`, but not both, to avoid any ambiguous precedence.

It's quite a lot easier to test RESTful APIs by providing clickable URLs in the browser.  I hope you find it useful!

Cheers!